### PR TITLE
Fixes for include and includes.

### DIFF
--- a/perky/__init__.py
+++ b/perky/__init__.py
@@ -414,16 +414,20 @@ def _include(o, filenames, key, recursive, encoding):
         isinstance(o, dict),
         "object must be a dict")
     dicts = []
-    for filename in filenames():
+    for filename in filenames(o):
         d = load(filename, encoding=encoding)
         if recursive:
-            d = include(d, include=include, includes=includes, recursive=True, encoding=encoding)
+            d = _include(d, filenames, key, recursive=True, encoding=encoding)
         dicts.append(d)
     dicts.append(o)
     final = dicts[0]
     for d in dicts[1:]:
         final.update(d)
-    del final[key]
+    try:
+        del final[key]
+    except KeyError:
+        # When traversing a set of files recursively, the leaves won't have includes set
+        pass
     return final
 
 @export
@@ -440,7 +444,7 @@ def include(o, *, recursive=True, encoding="utf-8"):
 def includes(o, *, recursive=True, encoding="utf-8"):
     def filenames(o):
         includes = o.get("includes")
-        if not include:
+        if not includes:
             return []
         return includes
     return _include(o, filenames, "includes", recursive=recursive, encoding=encoding)


### PR DESCRIPTION
* The filenames helper now takes the dictionary being operated on as a
  parameter so be sure to pass it.
* When recursively including files, the leaf files won't contain the
  "include" or "includes" key so do not error if it's missing.
* Typo in the variable name to check for imore filenames in includes.
* The function name and signature to recursively check for
  include/includes has changed.

This should allow things like this to work:
```
perky.includes({'includes': ['prime.pky', 'other.pky', 'test.pky']}, recursive=True)
```

I also noticed some things which were more design or feature changes and didn't address them, though:

*  The way this is currently implemented, a set of perky config files that use include or includes can only use one of those two features.  ie: Either all files in the set need to use `includes` or all files in the set need to use `include`.  Trying to mix the two won't work.  (Not even if the calling code calls both functions.  If the calling code calls `perky.includes()` first, all the `include` fields in the files will get merged into a single include entry in the dictionary.  Then, when the code calls `perky.include()` only the single include will be processed.  The same scenario exists with `perky.include()` being called first except that it is the `includes` entries which will get overwritten. Potential solutions:

    * Deprecate include as include enables a subset of the functionality that includes allows.
    * Reimplement include/includes as a single feature again so that users' set of config files can mix the two features together.

* I suspect that relative paths in include/includes won't operate the way the user expects.  It looks like relative filenames will be relative to the current working directory whereas users will probably expect that filenames will be relative to the perky file that contains the include.

* Similarly, I note that tilde expansion of include/includes filenames is not performed.  That's a feature that can be very helpful.