### PR TITLE
pyproject.toml: correct license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,6 @@ requires-python = ">=3.5"
 description-file = "README.md"
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
     ]


### PR DESCRIPTION
LICENSE is the MIT/Expat license, not a BSD-style license.